### PR TITLE
Add inline replies

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/.replit
+++ b/.replit
@@ -1,2 +1,0 @@
-language = "nodejs"
-run = "npm start"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Sentry-Djs is a powerful [Node.js](https://nodejs.org) module that allows you to
 
 ## Installation
 
-**Node.js 12.0.0 or newer is required.**  
+**Node.js 14.0.0 or newer is required.**  
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
 Without voice support: `npm install sentry-djs`  


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the functionality of inline replies to the `message.reply()` feature and includes options for allowed mentions as well with the `allowedMentions` object, following the same syntax as the rest of this package.

An example of how it would work:
```JS
client.on("message", async (message) {
  if (message.content.startsWith(`!reply`) {
    message.reply("Hello!", { tts: true, allowedMentions: { parse: [] } });
  }
});
```

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
